### PR TITLE
Remove kFingerprint field from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ You need to create a file called `config.h` in the same directory as `ferraris-c
 | `kPort`        | `int const`          | The **port** your SpaceAPI server is listening on        |
 | `kPath`        | `char const * const` | The **path** for the PUT request on your SpaceAPI server |
 | `kField`       | `char const * const` | The **key** of the field transmitted in the PUT request  |
-| `kFingerprint` | `char const * const` | Your SpaceAPI servers **TLS fingerprint**                |
 
 For the sake of simplicity, you can of course define these variables using `auto constexpr`. You should make sure to **_NEVER_** add this configuration file to your repository since this would compromise your network security.
 


### PR DESCRIPTION
It is not actually being used.

Furthermore, when using Let's Encrypt, the fingerprint changes every
1-2 months.

We should instead do hostname verification and use the fingerprint of
the Let's Encrypt root certificate. Not sure how easy that is on the
ESP.